### PR TITLE
feat: GitHub App認証のサポートを追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,8 +11,17 @@ SLACK_TEAM_ID=T0123456789
 # SlackプロフィールのメンバーIDで確認可能
 ADMIN_SLACK_USER=U0123456789
 
-# GitHub
+# GitHub認証モード（pat または github-app）
+GITHUB_AUTH_MODE=pat
+
+# --- PATモード（デフォルト） ---
 GITHUB_TOKEN=github_pat_your-token
+
+# --- GitHub Appモード ---
+# GITHUB_AUTH_MODE=github-app
+# GITHUB_APP_ID=12345
+# GITHUB_APP_PRIVATE_KEY_PATH=~/.claps/github-app.pem
+# GITHUB_APP_INSTALLATION_ID=67890
 
 # 監視対象リポジトリ (カンマ区切り)
 GITHUB_REPOS=owner/repo1,owner/repo2

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ curl -X POST http://localhost:3000/api/v1/tasks/<taskId>/answer \
 | `SLACK_APP_TOKEN` | `xapp-...` | Slack App Token (Socket Mode) |
 | `SLACK_CHANNEL_ID` | `C0123456789` | Notification channel ID |
 | `SLACK_TEAM_ID` | `T0123456789` | Slack workspace ID |
-| `GITHUB_TOKEN` | `github_pat_...` | GitHub Personal Access Token |
+| `GITHUB_TOKEN` | `github_pat_...` | GitHub Personal Access Token (PAT mode) |
 | `GITHUB_REPOS` | `owner/repo1,owner/repo2` | Monitored repositories (comma-separated) |
 
 ### Optional
@@ -179,6 +179,17 @@ curl -X POST http://localhost:3000/api/v1/tasks/<taskId>/answer \
 | `ADMIN_SLACK_USER` | - | Admin Slack user ID |
 | `ALLOWED_GITHUB_USERS` | - | Allowed GitHub users (comma-separated, initial value) |
 | `ALLOWED_SLACK_USERS` | - | Allowed Slack user IDs (comma-separated, initial value) |
+
+### GitHub App Authentication (Alternative to PAT)
+
+Instead of a PAT, you can use a GitHub App for bot-attributed commits (`キャラ名[bot]`) and short-lived tokens. See **[GitHub App Setup Guide](./docs/GITHUB_APP_SETUP.md)** for details.
+
+| Variable | Description |
+|----------|-------------|
+| `GITHUB_AUTH_MODE` | `pat` (default) or `github-app` |
+| `GITHUB_APP_ID` | GitHub App ID |
+| `GITHUB_APP_PRIVATE_KEY_PATH` | Path to `.pem` file (e.g. `~/.claps/github-app.pem`) |
+| `GITHUB_APP_INSTALLATION_ID` | Installation ID |
 
 ## Usage
 
@@ -278,6 +289,7 @@ See `src/messages.ts` for all available message keys.
 ## Documentation
 
 - [Design Document](./docs/DESIGN.md) - System architecture, processing flow, implementation details
+- [GitHub App Setup Guide](./docs/GITHUB_APP_SETUP.md) - GitHub App authentication setup
 - [Contributing Guide](./docs/CONTRIB.md) - Development setup, coding conventions
 - [Runbook](./docs/RUNBOOK.md) - Deployment, monitoring, troubleshooting
 

--- a/docs/GITHUB_APP_SETUP.md
+++ b/docs/GITHUB_APP_SETUP.md
@@ -1,0 +1,124 @@
+# GitHub App セットアップガイド
+
+CLAPS では GitHub Personal Access Token（PAT）に加えて、GitHub App 認証をサポートしています。
+GitHub App を使用すると、コミット著者が `キャラ名[bot]` として表示され、1時間有効の短命トークンによりセキュリティも向上します。
+
+## PAT との比較
+
+| | PAT | GitHub App |
+|---|-----|-----------|
+| コミット著者 | 個人アカウント名 | `キャラ名[bot]` |
+| トークン有効期限 | 長期（手動ローテーション） | 1時間（自動リフレッシュ） |
+| セットアップ | トークン1つ | App作成・インストール・秘密鍵 |
+| 推奨用途 | ローカル開発・テスト | 本番運用 |
+
+## 1. GitHub App の作成
+
+1. [GitHub App 作成ページ](https://github.com/settings/apps/new) を開く（Organization の場合は `https://github.com/organizations/{org}/settings/apps/new`）
+2. 以下を入力:
+
+| 項目 | 値 |
+|------|-----|
+| **GitHub App name** | キャラ名（例: `claris-bot`） |
+| **Description** | `claps自動実装エージェント - Issue対応・PR作成` |
+| **Homepage URL** | リポジトリURL（例: `https://github.com/jujucub/claps`） |
+
+3. **Webhook**: 「Active」のチェックを**外す**（claps はポーリング方式のため不要）
+
+## 2. Permissions の設定
+
+**Repository permissions** で以下を設定:
+
+| Permission | Access | 用途 |
+|-----------|--------|------|
+| **Contents** | Read and write | clone, fetch, push |
+| **Issues** | Read and write | Issue読み取り、コメント投稿 |
+| **Pull requests** | Read and write | PR作成 |
+| **Metadata** | Read-only | 自動付与 |
+
+それ以外の権限は不要です。設定したら **Create GitHub App** をクリック。
+
+## 3. Private Key の生成
+
+App 作成後の設定ページ下部「Private keys」セクションで:
+
+1. **Generate a private key** をクリック
+2. `.pem` ファイルがダウンロードされる
+3. 安全な場所に配置:
+
+```bash
+mkdir -p ~/.claps
+mv ~/Downloads/*.private-key.pem ~/.claps/github-app.pem
+chmod 600 ~/.claps/github-app.pem
+```
+
+> **重要**: 秘密鍵のパーミッションは `600` にしてください。claps 起動時にパーミッションを検証し、不適切な場合は警告が表示されます。
+
+## 4. App のインストール
+
+1. App 設定ページの左メニューから **Install App** を選択
+2. 対象のアカウントまたは Organization を選択
+3. **Only select repositories** で対象リポジトリを選んでインストール
+
+## 5. 必要な情報の確認
+
+環境変数に設定する3つの値を確認します:
+
+| 値 | 確認場所 |
+|----|---------|
+| **App ID** | App 設定ページ「General」→「About」セクションの「App ID」 |
+| **Private Key パス** | Step 3 で配置したパス（例: `~/.claps/github-app.pem`） |
+| **Installation ID** | インストール後の URL `https://github.com/settings/installations/{ID}` の末尾の数字 |
+
+## 6. 環境変数の設定
+
+`~/.claps/.env`（または `.env`）に以下を追加:
+
+```bash
+GITHUB_AUTH_MODE=github-app
+GITHUB_APP_ID=123456
+GITHUB_APP_PRIVATE_KEY_PATH=~/.claps/github-app.pem
+GITHUB_APP_INSTALLATION_ID=78901234
+```
+
+> `GITHUB_TOKEN` は設定不要です（`GITHUB_AUTH_MODE=github-app` の場合は無視されます）。
+
+## 7. 動作確認
+
+```bash
+npm run build && npm start
+```
+
+起動ログに以下が表示されれば成功です:
+
+```
+GitHub auth mode: github-app
+GitHub App token refreshed (expires: ...)
+GitHub App bot username: キャラ名[bot]
+```
+
+## トラブルシューティング
+
+### `GitHub App秘密鍵が見つかりません`
+
+`GITHUB_APP_PRIVATE_KEY_PATH` のパスを確認してください。`~` はホームディレクトリに展開されます。
+
+### `秘密鍵のパーミッションが ... です`
+
+```bash
+chmod 600 ~/.claps/github-app.pem
+```
+
+### トークンが1時間で切れる
+
+claps は git 操作（fetch/push）やAPI呼び出しの直前に自動でトークンをリフレッシュするため、通常は問題ありません。有効期限の10分前に自動更新されます。
+
+### Installation ID がわからない
+
+GitHub CLI で確認できます:
+
+```bash
+gh api /app/installations --jq '.[].id'
+```
+
+> `GITHUB_TOKEN` に App の JWT を設定する必要があるため、通常は URL から確認する方が簡単です。

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@line/bot-sdk": "^10.6.0",
+        "@octokit/auth-app": "^8.2.0",
         "@octokit/rest": "^21.0.0",
         "@slack/bolt": "^4.1.0",
         "dotenv": "^16.4.5",
@@ -698,6 +699,332 @@
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
+    "node_modules/@octokit/auth-app": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-8.2.0.tgz",
+      "integrity": "sha512-vVjdtQQwomrZ4V46B9LaCsxsySxGoHsyw6IYBov/TqJVROrlYdyNgw5q6tQbB7KZt53v1l1W53RiqTvpzL907g==",
+      "dependencies": {
+        "@octokit/auth-oauth-app": "^9.0.3",
+        "@octokit/auth-oauth-user": "^6.0.2",
+        "@octokit/request": "^10.0.6",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "toad-cache": "^3.7.0",
+        "universal-github-app-jwt": "^2.2.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-app/node_modules/@octokit/endpoint": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+      "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+      "dependencies": {
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-app/node_modules/@octokit/openapi-types": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="
+    },
+    "node_modules/@octokit/auth-app/node_modules/@octokit/request": {
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.7.tgz",
+      "integrity": "sha512-v93h0i1yu4idj8qFPZwjehoJx4j3Ntn+JhXsdJrG9pYaX6j/XRz2RmasMUHtNgQD39nrv/VwTWSqK0RNXR8upA==",
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.2",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "fast-content-type-parse": "^3.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-app/node_modules/@octokit/request-error": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
+      "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-app/node_modules/@octokit/types": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "dependencies": {
+        "@octokit/openapi-types": "^27.0.0"
+      }
+    },
+    "node_modules/@octokit/auth-app/node_modules/fast-content-type-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
+      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ]
+    },
+    "node_modules/@octokit/auth-oauth-app": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-9.0.3.tgz",
+      "integrity": "sha512-+yoFQquaF8OxJSxTb7rnytBIC2ZLbLqA/yb71I4ZXT9+Slw4TziV9j/kyGhUFRRTF2+7WlnIWsePZCWHs+OGjg==",
+      "dependencies": {
+        "@octokit/auth-oauth-device": "^8.0.3",
+        "@octokit/auth-oauth-user": "^6.0.2",
+        "@octokit/request": "^10.0.6",
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-app/node_modules/@octokit/endpoint": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+      "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+      "dependencies": {
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-app/node_modules/@octokit/openapi-types": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="
+    },
+    "node_modules/@octokit/auth-oauth-app/node_modules/@octokit/request": {
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.7.tgz",
+      "integrity": "sha512-v93h0i1yu4idj8qFPZwjehoJx4j3Ntn+JhXsdJrG9pYaX6j/XRz2RmasMUHtNgQD39nrv/VwTWSqK0RNXR8upA==",
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.2",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "fast-content-type-parse": "^3.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-app/node_modules/@octokit/request-error": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
+      "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-app/node_modules/@octokit/types": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "dependencies": {
+        "@octokit/openapi-types": "^27.0.0"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-app/node_modules/fast-content-type-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
+      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ]
+    },
+    "node_modules/@octokit/auth-oauth-device": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-device/-/auth-oauth-device-8.0.3.tgz",
+      "integrity": "sha512-zh2W0mKKMh/VWZhSqlaCzY7qFyrgd9oTWmTmHaXnHNeQRCZr/CXy2jCgHo4e4dJVTiuxP5dLa0YM5p5QVhJHbw==",
+      "dependencies": {
+        "@octokit/oauth-methods": "^6.0.2",
+        "@octokit/request": "^10.0.6",
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-device/node_modules/@octokit/endpoint": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+      "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+      "dependencies": {
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-device/node_modules/@octokit/openapi-types": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="
+    },
+    "node_modules/@octokit/auth-oauth-device/node_modules/@octokit/request": {
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.7.tgz",
+      "integrity": "sha512-v93h0i1yu4idj8qFPZwjehoJx4j3Ntn+JhXsdJrG9pYaX6j/XRz2RmasMUHtNgQD39nrv/VwTWSqK0RNXR8upA==",
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.2",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "fast-content-type-parse": "^3.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-device/node_modules/@octokit/request-error": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
+      "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-device/node_modules/@octokit/types": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "dependencies": {
+        "@octokit/openapi-types": "^27.0.0"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-device/node_modules/fast-content-type-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
+      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ]
+    },
+    "node_modules/@octokit/auth-oauth-user": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-6.0.2.tgz",
+      "integrity": "sha512-qLoPPc6E6GJoz3XeDG/pnDhJpTkODTGG4kY0/Py154i/I003O9NazkrwJwRuzgCalhzyIeWQ+6MDvkUmKXjg/A==",
+      "dependencies": {
+        "@octokit/auth-oauth-device": "^8.0.3",
+        "@octokit/oauth-methods": "^6.0.2",
+        "@octokit/request": "^10.0.6",
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-user/node_modules/@octokit/endpoint": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+      "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+      "dependencies": {
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-user/node_modules/@octokit/openapi-types": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="
+    },
+    "node_modules/@octokit/auth-oauth-user/node_modules/@octokit/request": {
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.7.tgz",
+      "integrity": "sha512-v93h0i1yu4idj8qFPZwjehoJx4j3Ntn+JhXsdJrG9pYaX6j/XRz2RmasMUHtNgQD39nrv/VwTWSqK0RNXR8upA==",
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.2",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "fast-content-type-parse": "^3.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-user/node_modules/@octokit/request-error": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
+      "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-user/node_modules/@octokit/types": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "dependencies": {
+        "@octokit/openapi-types": "^27.0.0"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-user/node_modules/fast-content-type-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
+      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ]
+    },
     "node_modules/@octokit/auth-token": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.2.tgz",
@@ -712,7 +1039,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.6.tgz",
       "integrity": "sha512-kIU8SLQkYWGp3pVKiYzA5OSaNF5EE03P/R8zEmmrG6XwOg5oBjXyQVVIauQ0dgau4zYhpZEhJrvIYt6oM+zZZA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^5.0.0",
         "@octokit/graphql": "^8.2.2",
@@ -752,6 +1078,94 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/@octokit/oauth-authorization-url": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-authorization-url/-/oauth-authorization-url-8.0.0.tgz",
+      "integrity": "sha512-7QoLPRh/ssEA/HuHBHdVdSgF8xNLz/Bc5m9fZkArJE5bb6NmVkDm3anKxXPmN1zh6b5WKZPRr3697xKT/yM3qQ==",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/oauth-methods": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-6.0.2.tgz",
+      "integrity": "sha512-HiNOO3MqLxlt5Da5bZbLV8Zarnphi4y9XehrbaFMkcoJ+FL7sMxH/UlUsCVxpddVu4qvNDrBdaTVE2o4ITK8ng==",
+      "dependencies": {
+        "@octokit/oauth-authorization-url": "^8.0.0",
+        "@octokit/request": "^10.0.6",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/oauth-methods/node_modules/@octokit/endpoint": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+      "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+      "dependencies": {
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/oauth-methods/node_modules/@octokit/openapi-types": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="
+    },
+    "node_modules/@octokit/oauth-methods/node_modules/@octokit/request": {
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.7.tgz",
+      "integrity": "sha512-v93h0i1yu4idj8qFPZwjehoJx4j3Ntn+JhXsdJrG9pYaX6j/XRz2RmasMUHtNgQD39nrv/VwTWSqK0RNXR8upA==",
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.2",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "fast-content-type-parse": "^3.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/oauth-methods/node_modules/@octokit/request-error": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
+      "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/oauth-methods/node_modules/@octokit/types": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "dependencies": {
+        "@octokit/openapi-types": "^27.0.0"
+      }
+    },
+    "node_modules/@octokit/oauth-methods/node_modules/fast-content-type-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
+      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ]
     },
     "node_modules/@octokit/openapi-types": {
       "version": "25.1.0",
@@ -1283,7 +1697,6 @@
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -1438,7 +1851,6 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -1650,8 +2062,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-<<<<<<< HEAD
-=======
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.0.tgz",
@@ -1665,149 +2075,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@vitest/coverage-v8": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.18.tgz",
-      "integrity": "sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.0.18",
-        "ast-v8-to-istanbul": "^0.3.10",
-        "istanbul-lib-coverage": "^3.2.2",
-        "istanbul-lib-report": "^3.0.1",
-        "istanbul-reports": "^3.2.0",
-        "magicast": "^0.5.1",
-        "obug": "^2.1.1",
-        "std-env": "^3.10.0",
-        "tinyrainbow": "^3.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@vitest/browser": "4.0.18",
-        "vitest": "4.0.18"
-      },
-      "peerDependenciesMeta": {
-        "@vitest/browser": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vitest/expect": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
-      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
-        "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.0.18",
-        "@vitest/utils": "4.0.18",
-        "chai": "^6.2.1",
-        "tinyrainbow": "^3.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/mocker": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
-      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/spy": "4.0.18",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.21"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0-0"
-      },
-      "peerDependenciesMeta": {
-        "msw": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vitest/pretty-format": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
-      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^3.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/runner": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
-      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/utils": "4.0.18",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/snapshot": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
-      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.0.18",
-        "magic-string": "^0.30.21",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/spy": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
-      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/utils": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
-      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.0.18",
-        "tinyrainbow": "^3.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
->>>>>>> 4ed444b (eslintでバージョン不一致による `npm install` でのエラーが出ていたので修正)
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -1827,7 +2094,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2361,7 +2627,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3551,7 +3816,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3943,6 +4207,14 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/toad-cache": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.0.tgz",
+      "integrity": "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -3980,7 +4252,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -4027,7 +4298,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4065,6 +4335,11 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
+    },
+    "node_modules/universal-github-app-jwt": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/universal-github-app-jwt/-/universal-github-app-jwt-2.2.2.tgz",
+      "integrity": "sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw=="
     },
     "node_modules/universal-user-agent": {
       "version": "7.0.3",
@@ -4122,164 +4397,6 @@
         "node": ">= 0.8"
       }
     },
-<<<<<<< HEAD
-=======
-    "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "esbuild": "^0.27.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.15"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "funding": {
-        "url": "https://github.com/vitejs/vite?sponsor=1"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      },
-      "peerDependencies": {
-        "@types/node": "^20.19.0 || >=22.12.0",
-        "jiti": ">=1.21.0",
-        "less": "^4.0.0",
-        "lightningcss": "^1.21.0",
-        "sass": "^1.70.0",
-        "sass-embedded": "^1.70.0",
-        "stylus": ">=0.54.8",
-        "sugarss": "^5.0.0",
-        "terser": "^5.16.0",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "jiti": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "lightningcss": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vitest": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
-      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@vitest/expect": "4.0.18",
-        "@vitest/mocker": "4.0.18",
-        "@vitest/pretty-format": "4.0.18",
-        "@vitest/runner": "4.0.18",
-        "@vitest/snapshot": "4.0.18",
-        "@vitest/spy": "4.0.18",
-        "@vitest/utils": "4.0.18",
-        "es-module-lexer": "^1.7.0",
-        "expect-type": "^1.2.2",
-        "magic-string": "^0.30.21",
-        "obug": "^2.1.1",
-        "pathe": "^2.0.3",
-        "picomatch": "^4.0.3",
-        "std-env": "^3.10.0",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^1.0.2",
-        "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.0.3",
-        "vite": "^6.0.0 || ^7.0.0",
-        "why-is-node-running": "^2.3.0"
-      },
-      "bin": {
-        "vitest": "vitest.mjs"
-      },
-      "engines": {
-        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@edge-runtime/vm": "*",
-        "@opentelemetry/api": "^1.9.0",
-        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.0.18",
-        "@vitest/browser-preview": "4.0.18",
-        "@vitest/browser-webdriverio": "4.0.18",
-        "@vitest/ui": "4.0.18",
-        "happy-dom": "*",
-        "jsdom": "*"
-      },
-      "peerDependenciesMeta": {
-        "@edge-runtime/vm": {
-          "optional": true
-        },
-        "@opentelemetry/api": {
-          "optional": true
-        },
-        "@types/node": {
-          "optional": true
-        },
-        "@vitest/browser-playwright": {
-          "optional": true
-        },
-        "@vitest/browser-preview": {
-          "optional": true
-        },
-        "@vitest/browser-webdriverio": {
-          "optional": true
-        },
-        "@vitest/ui": {
-          "optional": true
-        },
-        "happy-dom": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
-        }
-      }
-    },
->>>>>>> 4ed444b (eslintでバージョン不一致による `npm install` でのエラーが出ていたので修正)
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@line/bot-sdk": "^10.6.0",
+    "@octokit/auth-app": "^8.2.0",
     "@octokit/rest": "^21.0.0",
     "@slack/bolt": "^4.1.0",
     "dotenv": "^16.4.5",

--- a/src/github/auth.ts
+++ b/src/github/auth.ts
@@ -1,0 +1,189 @@
+/**
+ * claps - GitHub認証プロバイダー
+ * PAT と GitHub App の両方をサポートする統一的なトークン管理
+ */
+
+import * as fs from 'fs';
+import { Octokit } from '@octokit/rest';
+import { createAppAuth } from '@octokit/auth-app';
+import type { GitHubAuthConfig } from '../types/index.js';
+
+// トークンプロバイダーインターフェース
+export interface GitHubTokenProvider {
+  /** 有効なトークンを返す（自動リフレッシュ） */
+  GetToken(): Promise<string>;
+  /** 認証モードを返す */
+  GetAuthMode(): 'pat' | 'github-app';
+  /** Botユーザー名を返す（App: "app-name[bot]", PAT: undefined） */
+  GetBotUsername(): string | undefined;
+  /** 認証済みOctokitインスタンスを返す */
+  GetOctokit(): Promise<Octokit>;
+}
+
+// キャッシュされたトークン情報
+interface CachedToken {
+  readonly token: string;
+  readonly expiresAt: Date;
+}
+
+/**
+ * PAT（Personal Access Token）トークンプロバイダー
+ * 既存動作と完全に同等
+ */
+class PatTokenProvider implements GitHubTokenProvider {
+  private readonly _token: string;
+  private readonly _octokit: Octokit;
+
+  constructor(token: string) {
+    this._token = token;
+    this._octokit = new Octokit({ auth: token });
+  }
+
+  async GetToken(): Promise<string> {
+    return this._token;
+  }
+
+  GetAuthMode(): 'pat' {
+    return 'pat';
+  }
+
+  GetBotUsername(): string | undefined {
+    return undefined;
+  }
+
+  async GetOctokit(): Promise<Octokit> {
+    return this._octokit;
+  }
+}
+
+/**
+ * GitHub App トークンプロバイダー
+ * Installation Access Token を都度生成し、キャッシュと自動リフレッシュを行う
+ */
+class GitHubAppTokenProvider implements GitHubTokenProvider {
+  private readonly _appId: string;
+  private readonly _privateKey: string;
+  private readonly _installationId: number;
+  private _cachedToken: CachedToken | null = null;
+  private _refreshPromise: Promise<string> | null = null;
+  private _botUsername: string | undefined;
+
+  constructor(appId: string, privateKeyPath: string, installationId: number) {
+    this._appId = appId;
+    this._installationId = installationId;
+
+    // 秘密鍵を読み込む
+    const resolvedPath = privateKeyPath.replace(/^~/, process.env['HOME'] ?? '');
+    if (!fs.existsSync(resolvedPath)) {
+      throw new Error(`GitHub App秘密鍵が見つかりません: ${resolvedPath}`);
+    }
+
+    // ファイルパーミッションを検証
+    const stats = fs.statSync(resolvedPath);
+    const mode = stats.mode & 0o777;
+    if (mode !== 0o600 && mode !== 0o400) {
+      console.warn(`⚠️ GitHub App秘密鍵のパーミッションが ${mode.toString(8)} です。0600 に変更することを推奨します: ${resolvedPath}`);
+    }
+
+    this._privateKey = fs.readFileSync(resolvedPath, 'utf-8');
+  }
+
+  async GetToken(): Promise<string> {
+    // キャッシュされたトークンが有効なら再利用（有効期限の10分前まで）
+    if (this._cachedToken) {
+      const now = new Date();
+      const bufferMs = 10 * 60 * 1000; // 10分
+      if (now.getTime() + bufferMs < this._cachedToken.expiresAt.getTime()) {
+        return this._cachedToken.token;
+      }
+    }
+
+    // 既にリフレッシュ中のPromiseがあれば共有
+    if (this._refreshPromise) {
+      return this._refreshPromise;
+    }
+
+    this._refreshPromise = this._refreshToken();
+    try {
+      return await this._refreshPromise;
+    } finally {
+      this._refreshPromise = null;
+    }
+  }
+
+  GetAuthMode(): 'github-app' {
+    return 'github-app';
+  }
+
+  GetBotUsername(): string | undefined {
+    return this._botUsername;
+  }
+
+  async GetOctokit(): Promise<Octokit> {
+    const token = await this.GetToken();
+    return new Octokit({ auth: token });
+  }
+
+  private async _refreshToken(): Promise<string> {
+    const auth = createAppAuth({
+      appId: this._appId,
+      privateKey: this._privateKey,
+      installationId: this._installationId,
+    });
+
+    const result = await auth({ type: 'installation' });
+
+    // Botユーザー名を初回取得時にフェッチ
+    if (!this._botUsername) {
+      try {
+        const octokit = new Octokit({ auth: result.token });
+        const response = await octokit.apps.getAuthenticated();
+        const appSlug = response.data?.slug ?? response.data?.name ?? 'github-app';
+        this._botUsername = `${appSlug}[bot]`;
+        console.log(`GitHub App bot username: ${this._botUsername}`);
+      } catch (error) {
+        console.warn('GitHub Appのbot名取得に失敗:', error);
+      }
+    }
+
+    this._cachedToken = {
+      token: result.token,
+      expiresAt: new Date(result.expiresAt),
+    };
+
+    console.log(`GitHub App token refreshed (expires: ${result.expiresAt})`);
+    return result.token;
+  }
+}
+
+/**
+ * 設定に基づいてトークンプロバイダーを生成するファクトリ関数
+ */
+export function CreateTokenProvider(config: GitHubAuthConfig): GitHubTokenProvider {
+  if (config.mode === 'pat') {
+    return new PatTokenProvider(config.token);
+  }
+  return new GitHubAppTokenProvider(config.appId, config.privateKeyPath, config.installationId);
+}
+
+// シングルトン管理
+let _provider: GitHubTokenProvider | undefined;
+
+/**
+ * トークンプロバイダーを初期化する（起動時に1回呼ぶ）
+ */
+export function InitTokenProvider(config: GitHubAuthConfig): void {
+  _provider = CreateTokenProvider(config);
+  console.log(`GitHub auth initialized: mode=${config.mode}`);
+}
+
+/**
+ * トークンプロバイダーのシングルトンを取得する
+ * @throws InitTokenProvider が呼ばれていない場合
+ */
+export function GetTokenProvider(): GitHubTokenProvider {
+  if (!_provider) {
+    throw new Error('TokenProvider not initialized. Call InitTokenProvider first.');
+  }
+  return _provider;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -138,13 +138,19 @@ export interface AdminConfig {
   userMappings: UserMapping[];
 }
 
+// GitHub認証設定
+export type GitHubAuthConfig =
+  | { readonly mode: 'pat'; readonly token: string }
+  | { readonly mode: 'github-app'; readonly appId: string; readonly privateKeyPath: string; readonly installationId: number };
+
 // 設定
 export interface Config {
   readonly anthropicApiKey?: string; // Max Plan 使用時は不要
   readonly slackBotToken: string;
   readonly slackAppToken: string;
   readonly slackChannelId: string;
-  readonly githubToken: string;
+  readonly githubToken: string; // 後方互換: PATモード時のみ値が入る
+  readonly githubAuth: GitHubAuthConfig;
   readonly githubRepos: readonly string[];
   readonly approvalServerPort: number;
   readonly githubPollInterval: number;


### PR DESCRIPTION
## 概要

PATに加えてGitHub App認証をサポートする認証抽象化レイヤーを導入しました。

- **`src/github/auth.ts`（新規）**: `GitHubTokenProvider` インターフェースと、`PatTokenProvider` / `GitHubAppTokenProvider` の2実装を提供するモジュール。シングルトンで管理し、トークンの自動キャッシュ・リフレッシュ・並行リクエスト対策を含む
- **`src/types/index.ts`**: `GitHubAuthConfig` 型を追加し、`Config` に `githubAuth` フィールドを追加
- **`src/config.ts`**: `GITHUB_AUTH_MODE` 環境変数による分岐処理。`github-app` モード時は `GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY_PATH`, `GITHUB_APP_INSTALLATION_ID` を検証
- **全7箇所のトークン利用箇所を移行**: Poller, repo.ts, worktree.ts, mcp/setup.ts, runner.ts, index.ts

### 主なポイント

- **後方互換性**: `GITHUB_AUTH_MODE` 未設定時はデフォルトで `pat` モードが使用され、既存の動作がそのまま維持される
- **トークンリフレッシュ**: git操作（fetch/push）の直前に毎回 `GetToken()` を呼び、remote URLを更新。Appトークンの1時間有効期限に対応
- **並行リクエスト対策**: `GitHubAppTokenProvider` 内でリフレッシュ中のPromiseを共有し、重複リクエストを防止
- **秘密鍵セキュリティ**: PEMファイルのパーミッション（0600）を検証し、不適切な場合は警告

## レビューポイント

- **[`src/github/auth.ts`](src/github/auth.ts)**: 新規モジュール全体。特にトークンキャッシュの有効期限判定（10分バッファ）と並行リフレッシュの排他制御
- **[`src/claude/runner.ts`](src/claude/runner.ts)**: `new Promise()` の外でトークンを取得している点（非async callbackの制約対応）
- **[`src/git/worktree.ts`](src/git/worktree.ts)**: `CommitAndPush` と `CreatePullRequest` でのトークン注入タイミング
- **[`src/config.ts`](src/config.ts)**: 認証モード分岐のバリデーションロジック

## 注意事項

- MCP serverに渡したトークンは長時間セッションで失効する可能性あり（1時間以内のセッションは問題なし）。長時間運用が必要な場合は別途MCP設定の定期リフレッシュを検討
- `Config.githubToken` はPATモード時のみ値が入り、Appモードでは空文字列（後方互換フィールド）

## テスト計画

- [ ] PATモード: `GITHUB_AUTH_MODE` 未設定で既存動作が維持されることを確認
- [ ] Appモード: 環境変数を設定してApp認証が動作することを確認
- [ ] Octokitの動作: Issue一覧取得・コメント投稿がAppトークンで動作
- [ ] git clone/fetch: トークン埋め込みURLでクローン・フェッチが成功
- [ ] git push: worktreeからのプッシュがAppトークンで成功
- [ ] gh pr create: PR作成がAppトークンで成功
- [ ] コミット著者: コミットが `キャラ名[bot]` として表示される
- [ ] ビルド: `npm run build` & `npm run typecheck` が通る ✅