### PR TITLE
feat: GITHUB_REPOS未設定でも起動可能にする

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -50,15 +50,16 @@ export function LoadConfig(): Config {
   if (!slackChannelId) {
     throw new Error('SLACK_CHANNEL_ID is required');
   }
-  if (!githubToken) {
-    throw new Error('GITHUB_TOKEN is required');
-  }
-  if (!githubReposStr) {
-    throw new Error('GITHUB_REPOS is required');
-  }
 
-  // 環境変数からのリポジトリ設定
-  const envGithubRepos = githubReposStr.split(',').map((repo) => repo.trim());
+  // 環境変数からのリポジトリ設定（未設定の場合は空配列）
+  const envGithubRepos = githubReposStr
+    ? githubReposStr.split(',').map((repo) => repo.trim()).filter((repo) => repo !== '')
+    : [];
+
+  // GITHUB_TOKEN が未設定でも起動可能（GitHub連携機能は無効になる）
+  if (!githubToken && envGithubRepos.length > 0) {
+    throw new Error('GITHUB_TOKEN is required when GITHUB_REPOS is configured');
+  }
 
   const approvalServerPort = parseInt(
     process.env['APPROVAL_SERVER_PORT'] ?? '3001',

--- a/src/github/poller.ts
+++ b/src/github/poller.ts
@@ -89,7 +89,7 @@ function IsUserAllowed(username: string): boolean {
  */
 export function InitGitHubPoller(config: Config): void {
   _octokit = new Octokit({
-    auth: config.githubToken,
+    auth: config.githubToken ?? '',
   });
   _allowedUsers = config.allowedUsers;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,16 @@ import { HttpAdapter } from './http/adapter.js';
 // 作業ログの投稿間隔（ミリ秒）
 const WORK_LOG_INTERVAL_MS = 10000;
 
+/**
+ * GitHubトークンを取得する（未設定の場合はエラー）
+ */
+function RequireGitHubToken(): string {
+  if (!_config?.githubToken) {
+    throw new Error('GITHUB_TOKEN is not configured. GitHub repository operations are unavailable.');
+  }
+  return _config.githubToken;
+}
+
 // アプリケーション状態
 let _isRunning = false;
 let _config: Config | undefined;
@@ -126,9 +136,13 @@ async function Start(): Promise<void> {
     throw new Error('Slack adapter failed to start - cannot continue without Slack');
   }
 
-  // GitHub Poller を初期化・開始
-  InitGitHubPoller(_config);
-  StartGitHubPoller(_config, HandleGitHubIssue, HandleIssueClosed);
+  // GitHub Poller を初期化・開始（リポジトリが設定されている場合のみ）
+  if (_config.githubRepos.length > 0) {
+    InitGitHubPoller(_config);
+    StartGitHubPoller(_config, HandleGitHubIssue, HandleIssueClosed);
+  } else {
+    console.log('⏭️ GitHub Poller skipped: GITHUB_REPOS is not configured');
+  }
 
   // タスクキューのイベントを監視
   _taskQueue.On('added', OnTaskAdded);
@@ -399,7 +413,7 @@ async function ProcessSlackAsIssueTask(
     const repoPath = await GetOrCloneRepo(
       issueInfo.owner,
       issueInfo.repo,
-      _config.githubToken
+      RequireGitHubToken()
     );
 
     // 既存の worktree を取得（なければ作成）
@@ -504,7 +518,7 @@ async function ProcessSlackWithTargetRepo(
   try {
     // リポジトリをクローン（または更新）
     console.log(`Getting or cloning repo ${targetRepo}...`);
-    const repoPath = await GetOrCloneRepo(owner, repo, _config.githubToken);
+    const repoPath = await GetOrCloneRepo(owner, repo, RequireGitHubToken());
 
     // スレッドにtargetRepoを紐づける（同じスレッドでのメンションも同じworktreeで作業するため）
     sessionStore.LinkThreadToTargetRepo(slackMeta.threadTs, targetRepo);
@@ -609,7 +623,7 @@ async function ProcessLineTask(
       const owner = parts[0] as string;
       const repo = parts[1] as string;
 
-      const repoPath = await GetOrCloneRepo(owner, repo, _config.githubToken);
+      const repoPath = await GetOrCloneRepo(owner, repo, RequireGitHubToken());
       const worktreeIdentifier = Date.now();
       const { worktreeInfo } = await GetOrCreateWorktree(repoPath, owner, repo, worktreeIdentifier);
 
@@ -708,7 +722,7 @@ async function ProcessHttpTask(
       const owner = parts[0] as string;
       const repo = parts[1] as string;
 
-      const repoPath = await GetOrCloneRepo(owner, repo, _config.githubToken);
+      const repoPath = await GetOrCloneRepo(owner, repo, RequireGitHubToken());
       const worktreeIdentifier = Date.now();
       const { worktreeInfo } = await GetOrCreateWorktree(repoPath, owner, repo, worktreeIdentifier);
 
@@ -794,7 +808,7 @@ async function ProcessGitHubTask(
   try {
     // リポジトリをクローン（または更新）
     console.log(`Getting or cloning repo ${meta.owner}/${meta.repo}...`);
-    const repoPath = await GetOrCloneRepo(meta.owner, meta.repo, _config.githubToken);
+    const repoPath = await GetOrCloneRepo(meta.owner, meta.repo, RequireGitHubToken());
 
     // 既存の worktree があれば再利用、なければ新規作成
     console.log(`Getting or creating worktree for issue #${meta.issueNumber}...`);
@@ -967,7 +981,9 @@ function BuildSlackContext(
   threadTs: string,
   githubRepos: readonly string[]
 ): string {
-  const reposList = githubRepos.map(repo => `  - ${repo}`).join('\n');
+  const reposSection = githubRepos.length > 0
+    ? `\n監視対象GitHubリポジトリ:\n${githubRepos.map(repo => `  - ${repo}`).join('\n')}`
+    : '';
   return `
 ---
 Slackコンテキスト情報:
@@ -975,9 +991,7 @@ Slackコンテキスト情報:
 - Thread TS: ${threadTs}
 - User ID: ${userId}
 - このユーザーへの返信は <@${userId}> でメンションできます
-
-監視対象GitHubリポジトリ:
-${reposList}
+${reposSection}
 ---`;
 }
 
@@ -1047,15 +1061,15 @@ function BuildLineContext(
   targetRepo?: string,
   branchName?: string
 ): string {
-  const reposList = githubRepos.map(repo => `  - ${repo}`).join('\n');
+  const reposSection = githubRepos.length > 0
+    ? `\n監視対象GitHubリポジトリ:\n${githubRepos.map(repo => `  - ${repo}`).join('\n')}`
+    : '';
   let context = `
 ---
 LINEコンテキスト情報:
 - ソース: LINE Bot
 - User ID: ${meta.userId}
-
-監視対象GitHubリポジトリ:
-${reposList}`;
+${reposSection}`;
 
   if (targetRepo && branchName) {
     context += `
@@ -1082,16 +1096,16 @@ function BuildHttpContext(
   targetRepo?: string,
   branchName?: string
 ): string {
-  const reposList = githubRepos.map(repo => `  - ${repo}`).join('\n');
+  const reposSection = githubRepos.length > 0
+    ? `\n監視対象GitHubリポジトリ:\n${githubRepos.map(repo => `  - ${repo}`).join('\n')}`
+    : '';
   let context = `
 ---
 HTTPコンテキスト情報:
 - ソース: HTTP API
 - Correlation ID: ${meta.correlationId}
 ${meta.deviceId ? `- Device ID: ${meta.deviceId}` : ''}
-
-監視対象GitHubリポジトリ:
-${reposList}`;
+${reposSection}`;
 
   if (targetRepo && branchName) {
     context += `

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -144,7 +144,7 @@ export interface Config {
   readonly slackBotToken: string;
   readonly slackAppToken: string;
   readonly slackChannelId: string;
-  readonly githubToken: string;
+  readonly githubToken?: string;
   readonly githubRepos: readonly string[];
   readonly approvalServerPort: number;
   readonly githubPollInterval: number;


### PR DESCRIPTION
## 概要

`GITHUB_REPOS` と `GITHUB_TOKEN` を任意の環境変数に変更し、GitHub連携機能を使わない（Slackチャネル経由の会話のみ利用する）ケースでも起動できるようにしました。

### 変更点

- **`src/config.ts`**: `GITHUB_REPOS` の必須チェックを削除。未設定時は空配列に。`GITHUB_TOKEN` は `GITHUB_REPOS` が設定されている場合のみ必須に変更
- **`src/types/index.ts`**: `Config.githubToken` を optional に変更
- **`src/index.ts`**: `RequireGitHubToken()` ヘルパーを追加し、トークン未設定時に明確なエラーを返す。GitHub Poller の起動を `githubRepos.length > 0` でガード。コンテキストビルダーでリポジトリが空の場合はセクションを省略
- **`src/github/poller.ts`**: `config.githubToken` の型安全対応

### 動作パターン

| GITHUB_REPOS | GITHUB_TOKEN | 動作 |
|---|---|---|
| 未設定 | 未設定 | 起動OK。GitHub Pollerスキップ。Slack会話のみ |
| 未設定 | 設定済み | 起動OK。GitHub Pollerスキップ |
| 設定済み | 未設定 | **起動エラー**（GITHUB_TOKEN必須） |
| 設定済み | 設定済み | 従来通りフル機能 |

## レビューポイント

- `RequireGitHubToken()` でトークン未設定時のガード: [src/index.ts](src/index.ts) の `RequireGitHubToken()` 関数。リポジトリ操作が呼ばれた時点でトークンが無ければ即座にエラーを投げる設計
- Slack の `!repo add` 等で後からリポジトリを追加した場合、`GITHUB_TOKEN` が無いとリポジトリ操作でランタイムエラーになる点は想定通り

## Test plan

- [ ] `GITHUB_REPOS` と `GITHUB_TOKEN` を未設定で起動し、Slack 経由の会話が正常に動作することを確認
- [ ] `GITHUB_REPOS` を設定し `GITHUB_TOKEN` を未設定で起動した場合にエラーになることを確認
- [ ] 両方設定済みで従来通りの動作を確認