### PR TITLE
feat: CLAPS_HOME環境変数で設定ディレクトリを変更可能にする

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,3 @@
-# 設定ディレクトリ（複数インスタンス起動時に変更）
-# CLAPS_HOME=~/.claps-clarisse
-
 # Anthropic API（Max Plan使用時は不要）
 # ANTHROPIC_API_KEY=sk-ant-...
 

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# 設定ディレクトリ（複数インスタンス起動時に変更）
+# CLAPS_HOME=~/.claps-clarisse
+
 # Anthropic API（Max Plan使用時は不要）
 # ANTHROPIC_API_KEY=sk-ant-...
 

--- a/src/admin/store.ts
+++ b/src/admin/store.ts
@@ -5,12 +5,13 @@
 
 import fs from 'fs';
 import path from 'path';
-import os from 'os';
 import type { AdminConfig } from '../types/index.js';
+import { GetClapsDir } from '../git/repo.js';
 
-// 設定ファイルパス
-const CONFIG_DIR = path.join(os.homedir(), '.claps');
-const CONFIG_FILE = path.join(CONFIG_DIR, 'admin-config.json');
+// 設定ファイルパスを取得する（遅延評価）
+function GetConfigFile(): string {
+  return path.join(GetClapsDir(), 'admin-config.json');
+}
 
 // 変更通知コールバック
 type ConfigChangeCallback = (config: AdminConfig) => void;
@@ -36,8 +37,8 @@ function GetDefaultConfig(): AdminConfig {
  */
 export function LoadAdminConfig(): AdminConfig {
   try {
-    if (fs.existsSync(CONFIG_FILE)) {
-      const data = fs.readFileSync(CONFIG_FILE, 'utf-8');
+    if (fs.existsSync(GetConfigFile())) {
+      const data = fs.readFileSync(GetConfigFile(), 'utf-8');
       const parsed = JSON.parse(data) as Partial<AdminConfig>;
 
       // 型の検証とデフォルト値のマージ
@@ -62,7 +63,7 @@ export function LoadAdminConfig(): AdminConfig {
           : [],
       };
 
-      console.log('Loaded admin config from', CONFIG_FILE);
+      console.log('Loaded admin config from', GetConfigFile());
       return _currentConfig;
     }
   } catch (error) {
@@ -79,17 +80,17 @@ export function LoadAdminConfig(): AdminConfig {
 export function SaveAdminConfig(config: AdminConfig): void {
   try {
     // ディレクトリがなければ作成
-    if (!fs.existsSync(CONFIG_DIR)) {
-      fs.mkdirSync(CONFIG_DIR, { mode: 0o700 });
+    if (!fs.existsSync(GetClapsDir())) {
+      fs.mkdirSync(GetClapsDir(), { mode: 0o700 });
     }
 
     // 設定をファイルに保存（所有者のみ読み書き可能）
-    fs.writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2), {
+    fs.writeFileSync(GetConfigFile(), JSON.stringify(config, null, 2), {
       mode: 0o600,
     });
 
     _currentConfig = config;
-    console.log('Saved admin config to', CONFIG_FILE);
+    console.log('Saved admin config to', GetConfigFile());
 
     // コールバックを呼び出し
     for (const callback of _callbacks) {
@@ -126,7 +127,7 @@ export function OnConfigChange(callback: ConfigChangeCallback): void {
  * 設定ファイルが存在するかチェックする
  */
 export function HasAdminConfig(): boolean {
-  return fs.existsSync(CONFIG_FILE);
+  return fs.existsSync(GetConfigFile());
 }
 
 /**

--- a/src/approval/server.ts
+++ b/src/approval/server.ts
@@ -9,9 +9,9 @@ import { v4 as uuidv4 } from 'uuid';
 import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
-import os from 'os';
 import type { HookInput, HookOutput, TaskMetadata } from '../types/index.js';
 import type { NotificationRouter } from '../channel/router.js';
+import { GetClapsDir } from '../git/repo.js';
 
 // サーバー状態
 let _server: Server | undefined;
@@ -19,8 +19,11 @@ let _app: Express | undefined;
 
 // 認証トークン
 let _authToken: string | undefined;
-const AUTH_TOKEN_DIR = path.join(os.homedir(), '.claps');
-const AUTH_TOKEN_FILE = path.join(AUTH_TOKEN_DIR, 'auth-token');
+
+// 認証トークンファイルパスを取得する（遅延評価）
+function GetAuthTokenFile(): string {
+  return path.join(GetClapsDir(), 'auth-token');
+}
 
 // 通知ルーターへの参照（承認リクエスト送信用）
 let _router: NotificationRouter | undefined;
@@ -32,14 +35,14 @@ function GenerateAuthToken(): string {
   const token = crypto.randomBytes(32).toString('hex');
 
   // ディレクトリがなければ作成
-  if (!fs.existsSync(AUTH_TOKEN_DIR)) {
-    fs.mkdirSync(AUTH_TOKEN_DIR, { mode: 0o700 });
+  if (!fs.existsSync(GetClapsDir())) {
+    fs.mkdirSync(GetClapsDir(), { mode: 0o700 });
   }
 
   // トークンをファイルに保存（所有者のみ読み書き可能）
-  fs.writeFileSync(AUTH_TOKEN_FILE, token, { mode: 0o600 });
+  fs.writeFileSync(GetAuthTokenFile(), token, { mode: 0o600 });
 
-  console.log(`Auth token saved to ${AUTH_TOKEN_FILE}`);
+  console.log(`Auth token saved to ${GetAuthTokenFile()}`);
   return token;
 }
 
@@ -238,8 +241,8 @@ export function StartApprovalServer(port: number): Promise<void> {
 export function StopApprovalServer(): Promise<void> {
   return new Promise((resolve) => {
     // 認証トークンファイルを削除
-    if (fs.existsSync(AUTH_TOKEN_FILE)) {
-      fs.unlinkSync(AUTH_TOKEN_FILE);
+    if (fs.existsSync(GetAuthTokenFile())) {
+      fs.unlinkSync(GetAuthTokenFile());
       console.log('Auth token file removed');
     }
     _authToken = undefined;

--- a/src/character.ts
+++ b/src/character.ts
@@ -5,8 +5,8 @@
  */
 
 import * as fs from 'fs';
-import * as os from 'os';
 import * as path from 'path';
+import { GetClapsDir } from './git/repo.js';
 
 // デフォルトのキャラクタ設定（クラリス - ツンデレメイド）
 const DEFAULT_CHARACTER_PROMPT = `あなたは「クラリス」です。ツンデレなメイドのキャラクターとして応答してください。
@@ -48,8 +48,10 @@ const DEFAULT_CHARACTER_PROMPT = `あなたは「クラリス」です。ツン�
 
 この口調で応答しながら、技術的な内容は正確に伝えてください。`;
 
-// キャラクタ設定ファイルのパス
-const CHARACTER_FILE_PATH = path.join(os.homedir(), '.claps', 'character.md');
+// キャラクタ設定ファイルのパスを取得する（遅延評価）
+function GetCharacterFilePathInternal(): string {
+  return path.join(GetClapsDir(), 'character.md');
+}
 
 // キャッシュ（ファイル変更検知用）
 let _cachedPrompt: string | undefined;
@@ -61,7 +63,7 @@ let _cachedMtime: number | undefined;
  */
 export function LoadCharacterPrompt(): string {
   try {
-    const stat = fs.statSync(CHARACTER_FILE_PATH);
+    const stat = fs.statSync(GetCharacterFilePathInternal());
     const mtime = stat.mtimeMs;
 
     // キャッシュが有効ならそのまま返す
@@ -69,7 +71,7 @@ export function LoadCharacterPrompt(): string {
       return _cachedPrompt;
     }
 
-    const content = fs.readFileSync(CHARACTER_FILE_PATH, 'utf-8').trim();
+    const content = fs.readFileSync(GetCharacterFilePathInternal(), 'utf-8').trim();
     if (content.length === 0) {
       return DEFAULT_CHARACTER_PROMPT;
     }
@@ -95,5 +97,5 @@ export function GetDefaultCharacterPrompt(): string {
  * キャラクタ設定ファイルのパスを取得する
  */
 export function GetCharacterFilePath(): string {
-  return CHARACTER_FILE_PATH;
+  return GetCharacterFilePathInternal();
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,18 +4,18 @@
 
 import * as dotenv from 'dotenv';
 import * as fs from 'fs';
-import * as os from 'os';
 import * as path from 'path';
 import type { Config, AllowedUsers, ChannelConfig, ReflectionConfig } from './types/index.js';
 import { LoadAdminConfig, HasAdminConfig } from './admin/store.js';
+import { GetClapsDir } from './git/repo.js';
 
-// ~/.claps/.env を優先的に読み込む（存在する場合）
-const clapsEnvPath = path.join(os.homedir(), '.claps', '.env');
+// プロジェクトルートの .env を先に読み込む（CLAPS_HOME を取得するため）
+dotenv.config();
+
+// GetClapsDir()/.env が存在すれば追加読み込み（override: true で上書き）
+const clapsEnvPath = path.join(GetClapsDir(), '.env');
 if (fs.existsSync(clapsEnvPath)) {
-  dotenv.config({ path: clapsEnvPath });
-} else {
-  // プロジェクトルートの .env を読み込む
-  dotenv.config();
+  dotenv.config({ path: clapsEnvPath, override: true });
 }
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,13 +9,13 @@ import type { Config, AllowedUsers, ChannelConfig, ReflectionConfig } from './ty
 import { LoadAdminConfig, HasAdminConfig } from './admin/store.js';
 import { GetClapsDir } from './git/repo.js';
 
-// プロジェクトルートの .env を先に読み込む（CLAPS_HOME を取得するため）
-dotenv.config();
-
-// GetClapsDir()/.env が存在すれば追加読み込み（override: true で上書き）
+// CLAPS_HOME/.env を優先的に読み込む（存在する場合）
 const clapsEnvPath = path.join(GetClapsDir(), '.env');
 if (fs.existsSync(clapsEnvPath)) {
-  dotenv.config({ path: clapsEnvPath, override: true });
+  dotenv.config({ path: clapsEnvPath });
+} else {
+  // プロジェクトルートの .env を読み込む
+  dotenv.config();
 }
 
 /**

--- a/src/git/repo.ts
+++ b/src/git/repo.ts
@@ -8,13 +8,30 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
+// --home 引数のキャッシュ
+let _clapsHomeFromArgs: string | undefined;
+let _argsParsed = false;
+
+/**
+ * process.argv から --home 引数を取得する
+ */
+function ParseHomeArg(): string | undefined {
+  if (!_argsParsed) {
+    const idx = process.argv.indexOf('--home');
+    if (idx !== -1 && idx + 1 < process.argv.length) {
+      _clapsHomeFromArgs = process.argv[idx + 1];
+    }
+    _argsParsed = true;
+  }
+  return _clapsHomeFromArgs;
+}
+
 /**
  * .claps ディレクトリのパスを取得する
- * CLAPS_HOME 環境変数が設定されている場合はそのパスを使用し、
- * 未設定の場合は ~/.claps/ を返す（後方互換）
+ * 優先順位: --home 引数 > CLAPS_HOME 環境変数 > ~/.claps（後方互換）
  */
 export function GetClapsDir(): string {
-  return process.env['CLAPS_HOME'] ?? path.join(os.homedir(), '.claps');
+  return ParseHomeArg() ?? process.env['CLAPS_HOME'] ?? path.join(os.homedir(), '.claps');
 }
 
 /**

--- a/src/git/repo.ts
+++ b/src/git/repo.ts
@@ -10,10 +10,11 @@ import * as path from 'path';
 
 /**
  * .claps ディレクトリのパスを取得する
- * すべてのデータは ~/.claps/ に保存される
+ * CLAPS_HOME 環境変数が設定されている場合はそのパスを使用し、
+ * 未設定の場合は ~/.claps/ を返す（後方互換）
  */
 export function GetClapsDir(): string {
-  return path.join(os.homedir(), '.claps');
+  return process.env['CLAPS_HOME'] ?? path.join(os.homedir(), '.claps');
 }
 
 /**

--- a/src/history/store.ts
+++ b/src/history/store.ts
@@ -5,11 +5,13 @@
 
 import fs from 'fs';
 import path from 'path';
-import os from 'os';
 import type { WorkHistoryRecord } from '../types/index.js';
+import { GetClapsDir } from '../git/repo.js';
 
-// 履歴保存ディレクトリ
-const HISTORY_BASE_DIR = path.join(os.homedir(), '.claps', 'history');
+// 履歴保存ディレクトリを取得する（遅延評価）
+function GetHistoryBaseDir(): string {
+  return path.join(GetClapsDir(), 'history');
+}
 
 /**
  * 日付文字列（YYYY-MM-DD）を取得する
@@ -27,7 +29,7 @@ function FormatDate(date: Date): string {
 function GetUserDir(userId: string): string {
   // ユーザーIDをサニタイズ（ディレクトリトラバーサル防止）
   const safeUserId = userId.replace(/[^a-zA-Z0-9_-]/g, '_');
-  return path.join(HISTORY_BASE_DIR, safeUserId);
+  return path.join(GetHistoryBaseDir(), safeUserId);
 }
 
 /**
@@ -162,17 +164,17 @@ export class HistoryStore {
    * 指定日付にレコードが存在するかチェックする
    */
   HasRecordsForDate(date: Date): boolean {
-    if (!fs.existsSync(HISTORY_BASE_DIR)) {
+    if (!fs.existsSync(GetHistoryBaseDir())) {
       return false;
     }
 
     const dateStr = FormatDate(date);
 
     try {
-      const userDirs = fs.readdirSync(HISTORY_BASE_DIR);
+      const userDirs = fs.readdirSync(GetHistoryBaseDir());
 
       for (const userDir of userDirs) {
-        const userPath = path.join(HISTORY_BASE_DIR, userDir);
+        const userPath = path.join(GetHistoryBaseDir(), userDir);
 
         if (!fs.statSync(userPath).isDirectory()) {
           continue;
@@ -198,7 +200,7 @@ export class HistoryStore {
    * 指定日数内にアクティブだったユーザーIDの一覧を取得する
    */
   GetActiveUsers(days: number): readonly string[] {
-    if (!fs.existsSync(HISTORY_BASE_DIR)) {
+    if (!fs.existsSync(GetHistoryBaseDir())) {
       return [];
     }
 
@@ -214,10 +216,10 @@ export class HistoryStore {
     }
 
     try {
-      const userDirs = fs.readdirSync(HISTORY_BASE_DIR);
+      const userDirs = fs.readdirSync(GetHistoryBaseDir());
 
       for (const userDir of userDirs) {
-        const userPath = path.join(HISTORY_BASE_DIR, userDir);
+        const userPath = path.join(GetHistoryBaseDir(), userDir);
 
         // ディレクトリでなければスキップ
         if (!fs.statSync(userPath).isDirectory()) {

--- a/src/http/adapter.ts
+++ b/src/http/adapter.ts
@@ -7,7 +7,6 @@ import express from 'express';
 import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
-import os from 'os';
 import { v4 as uuidv4 } from 'uuid';
 import type {
   TaskSource,
@@ -25,10 +24,12 @@ import { CreateHttpApiRouter, type PendingTaskState, type PendingApprovalInfo, t
 import type { AdapterRegistry } from '../channel/registry.js';
 import type { Express } from 'express';
 import type { Server } from 'http';
+import { GetClapsDir } from '../git/repo.js';
 
-// 認証トークンファイルパス
-const AUTH_TOKEN_DIR = path.join(os.homedir(), '.claps');
-const AUTH_TOKEN_FILE = path.join(AUTH_TOKEN_DIR, 'auth-token');
+// 認証トークンファイルパスを取得する（遅延評価）
+function GetAuthTokenFile(): string {
+  return path.join(GetClapsDir(), 'auth-token');
+}
 
 /**
  * Deferred Promise
@@ -260,8 +261,8 @@ export class HttpAdapter implements ChannelAdapter {
    */
   private _validateToken(token: string): boolean {
     try {
-      if (!fs.existsSync(AUTH_TOKEN_FILE)) return false;
-      const storedToken = fs.readFileSync(AUTH_TOKEN_FILE, 'utf-8').trim();
+      if (!fs.existsSync(GetAuthTokenFile())) return false;
+      const storedToken = fs.readFileSync(GetAuthTokenFile(), 'utf-8').trim();
       if (storedToken.length === 0) return false;
 
       // タイミング攻撃を防ぐため定数時間比較

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ import {
   RemoveWorktree,
   InitializeWorkspace,
 } from './git/worktree.js';
-import { GetOrCloneRepo, GetWorkspacePath } from './git/repo.js';
+import { GetOrCloneRepo, GetWorkspacePath, GetClapsDir } from './git/repo.js';
 import {
   GetSlackUserForGitHub,
   GetAdminSlackUser,
@@ -71,6 +71,7 @@ let _router: NotificationRouter | undefined;
  */
 async function Start(): Promise<void> {
   console.log(Msg('console.startup'));
+  console.log(`CLAPS_HOME: ${GetClapsDir()}`);
 
   // 設定を読み込む
   _config = LoadConfig();

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -5,8 +5,8 @@
  */
 
 import * as fs from 'fs';
-import * as os from 'os';
 import * as path from 'path';
+import { GetClapsDir } from './git/repo.js';
 
 // メッセージ設定
 interface MessageConfig {
@@ -125,8 +125,10 @@ const DEFAULT_MESSAGES: Readonly<Record<string, string>> = {
   'suggestion.execute': '{emoji} 提案「{title}」をタスクとして実行いたしますわ',
 };
 
-// 設定ファイルのパス
-const MESSAGES_FILE_PATH = path.join(os.homedir(), '.claps', 'messages.json');
+// 設定ファイルのパスを取得する（遅延評価）
+function GetMessagesFilePathInternal(): string {
+  return path.join(GetClapsDir(), 'messages.json');
+}
 
 // キャッシュ
 let _cachedConfig: MessageConfig | undefined;
@@ -145,7 +147,7 @@ function LoadMessageConfig(): MessageConfig {
   };
 
   try {
-    const stat = fs.statSync(MESSAGES_FILE_PATH);
+    const stat = fs.statSync(GetMessagesFilePathInternal());
     const mtime = stat.mtimeMs;
 
     // キャッシュが有効ならそのまま返す
@@ -153,7 +155,7 @@ function LoadMessageConfig(): MessageConfig {
       return _cachedConfig;
     }
 
-    const content = fs.readFileSync(MESSAGES_FILE_PATH, 'utf-8').trim();
+    const content = fs.readFileSync(GetMessagesFilePathInternal(), 'utf-8').trim();
     if (content.length === 0) {
       return defaultConfig;
     }
@@ -239,7 +241,7 @@ export function GetBotName(): string {
  * メッセージ設定ファイルのパスを取得する
  */
 export function GetMessagesFilePath(): string {
-  return MESSAGES_FILE_PATH;
+  return GetMessagesFilePathInternal();
 }
 
 /**

--- a/src/reflection/intent-store.ts
+++ b/src/reflection/intent-store.ts
@@ -5,11 +5,13 @@
 
 import fs from 'fs';
 import path from 'path';
-import os from 'os';
 import type { UserIntent } from '../types/index.js';
+import { GetClapsDir } from '../git/repo.js';
 
-// 保存ディレクトリ
-const INTENTS_DIR = path.join(os.homedir(), '.claps', 'intents');
+// 保存ディレクトリを取得する（遅延評価）
+function GetIntentsDir(): string {
+  return path.join(GetClapsDir(), 'intents');
+}
 
 /**
  * ユーザーIDをサニタイズしてファイル名に使用する
@@ -26,7 +28,7 @@ export class IntentStore {
    * ユーザーのインテントを取得する
    */
   Get(userId: string): UserIntent | undefined {
-    const filePath = path.join(INTENTS_DIR, `${SanitizeUserId(userId)}.json`);
+    const filePath = path.join(GetIntentsDir(), `${SanitizeUserId(userId)}.json`);
 
     if (!fs.existsSync(filePath)) {
       return undefined;
@@ -46,11 +48,11 @@ export class IntentStore {
    */
   Save(intent: UserIntent): void {
     try {
-      if (!fs.existsSync(INTENTS_DIR)) {
-        fs.mkdirSync(INTENTS_DIR, { recursive: true, mode: 0o700 });
+      if (!fs.existsSync(GetIntentsDir())) {
+        fs.mkdirSync(GetIntentsDir(), { recursive: true, mode: 0o700 });
       }
 
-      const filePath = path.join(INTENTS_DIR, `${SanitizeUserId(intent.userId)}.json`);
+      const filePath = path.join(GetIntentsDir(), `${SanitizeUserId(intent.userId)}.json`);
       fs.writeFileSync(filePath, JSON.stringify(intent, null, 2), { mode: 0o600 });
 
       console.log(`Intent saved for user ${intent.userId}`);
@@ -63,18 +65,18 @@ export class IntentStore {
    * 全ユーザーのインテントを取得する
    */
   GetAll(): readonly UserIntent[] {
-    if (!fs.existsSync(INTENTS_DIR)) {
+    if (!fs.existsSync(GetIntentsDir())) {
       return [];
     }
 
     const intents: UserIntent[] = [];
 
     try {
-      const files = fs.readdirSync(INTENTS_DIR).filter((f) => f.endsWith('.json'));
+      const files = fs.readdirSync(GetIntentsDir()).filter((f) => f.endsWith('.json'));
 
       for (const file of files) {
         try {
-          const content = fs.readFileSync(path.join(INTENTS_DIR, file), 'utf-8');
+          const content = fs.readFileSync(path.join(GetIntentsDir(), file), 'utf-8');
           intents.push(JSON.parse(content) as UserIntent);
         } catch {
           // 不正なファイルはスキップ

--- a/src/reflection/store.ts
+++ b/src/reflection/store.ts
@@ -5,11 +5,13 @@
 
 import fs from 'fs';
 import path from 'path';
-import os from 'os';
 import type { ReflectionResult, TaskSuggestion } from '../types/index.js';
+import { GetClapsDir } from '../git/repo.js';
 
-// 保存ディレクトリ
-const REFLECTIONS_DIR = path.join(os.homedir(), '.claps', 'reflections');
+// 保存ディレクトリを取得する（遅延評価）
+function GetReflectionsDir(): string {
+  return path.join(GetClapsDir(), 'reflections');
+}
 
 /**
  * 内省結果ストアクラス
@@ -20,11 +22,11 @@ export class ReflectionStore {
    */
   Save(result: ReflectionResult): void {
     try {
-      if (!fs.existsSync(REFLECTIONS_DIR)) {
-        fs.mkdirSync(REFLECTIONS_DIR, { recursive: true, mode: 0o700 });
+      if (!fs.existsSync(GetReflectionsDir())) {
+        fs.mkdirSync(GetReflectionsDir(), { recursive: true, mode: 0o700 });
       }
 
-      const filePath = path.join(REFLECTIONS_DIR, `${result.date}.json`);
+      const filePath = path.join(GetReflectionsDir(), `${result.date}.json`);
       fs.writeFileSync(filePath, JSON.stringify(result, null, 2), { mode: 0o600 });
 
       console.log(`Reflection saved: ${result.date}`);
@@ -37,12 +39,12 @@ export class ReflectionStore {
    * 最新の内省結果を取得する
    */
   GetLatest(): ReflectionResult | undefined {
-    if (!fs.existsSync(REFLECTIONS_DIR)) {
+    if (!fs.existsSync(GetReflectionsDir())) {
       return undefined;
     }
 
     try {
-      const files = fs.readdirSync(REFLECTIONS_DIR)
+      const files = fs.readdirSync(GetReflectionsDir())
         .filter((f) => f.endsWith('.json'))
         .sort()
         .reverse();
@@ -52,7 +54,7 @@ export class ReflectionStore {
       }
 
       const latestFile = files[0] as string;
-      const filePath = path.join(REFLECTIONS_DIR, latestFile);
+      const filePath = path.join(GetReflectionsDir(), latestFile);
       const content = fs.readFileSync(filePath, 'utf-8');
       return JSON.parse(content) as ReflectionResult;
     } catch (error) {
@@ -65,7 +67,7 @@ export class ReflectionStore {
    * 指定日の内省結果を取得する
    */
   GetByDate(date: string): ReflectionResult | undefined {
-    const filePath = path.join(REFLECTIONS_DIR, `${date}.json`);
+    const filePath = path.join(GetReflectionsDir(), `${date}.json`);
 
     if (!fs.existsSync(filePath)) {
       return undefined;

--- a/src/session/store.ts
+++ b/src/session/store.ts
@@ -6,8 +6,8 @@
 
 import fs from 'fs';
 import path from 'path';
-import os from 'os';
 import type { TaskSource, UserMapping } from '../types/index.js';
+import { GetClapsDir } from '../git/repo.js';
 
 // セッション取得時の戻り値型
 export interface SessionResult {
@@ -49,9 +49,10 @@ interface SerializedStore {
   readonly threadToTargetRepo: Record<string, string>;
 }
 
-// 永続化ファイルパス
-const SESSIONS_DIR = path.join(os.homedir(), '.claps');
-const SESSIONS_FILE = path.join(SESSIONS_DIR, 'sessions.json');
+// 永続化ファイルパスを取得する（遅延評価）
+function GetSessionsFile(): string {
+  return path.join(GetClapsDir(), 'sessions.json');
+}
 
 /**
  * セッションストアクラス
@@ -75,11 +76,11 @@ class SessionStore {
    */
   private _load(): void {
     try {
-      if (!fs.existsSync(SESSIONS_FILE)) {
+      if (!fs.existsSync(GetSessionsFile())) {
         return;
       }
 
-      const data = fs.readFileSync(SESSIONS_FILE, 'utf-8');
+      const data = fs.readFileSync(GetSessionsFile(), 'utf-8');
       const parsed = JSON.parse(data) as Partial<SerializedStore>;
       const now = Date.now();
 
@@ -123,8 +124,8 @@ class SessionStore {
    */
   private _save(): void {
     try {
-      if (!fs.existsSync(SESSIONS_DIR)) {
-        fs.mkdirSync(SESSIONS_DIR, { recursive: true, mode: 0o700 });
+      if (!fs.existsSync(GetClapsDir())) {
+        fs.mkdirSync(GetClapsDir(), { recursive: true, mode: 0o700 });
       }
 
       const serialized: SerializedStore = {
@@ -143,7 +144,7 @@ class SessionStore {
         threadToTargetRepo: Object.fromEntries(this._threadToTargetRepo),
       };
 
-      fs.writeFileSync(SESSIONS_FILE, JSON.stringify(serialized, null, 2), { mode: 0o600 });
+      fs.writeFileSync(GetSessionsFile(), JSON.stringify(serialized, null, 2), { mode: 0o600 });
     } catch (error) {
       console.error('Failed to save sessions:', error);
     }


### PR DESCRIPTION
## 概要

同一PCで複数のclapsインスタンスを同時運用できるよう、`CLAPS_HOME` 環境変数でベースディレクトリを差し替え可能にしました。未設定時は従来通り `~/.claps` を使用するため、後方互換性があります。

### 主な変更点

- **`src/git/repo.ts`**: `GetClapsDir()` が `CLAPS_HOME` 環境変数を参照するように変更
- **`src/config.ts`**: `.env` 読み込み順序を変更（プロジェクト `.env` → `CLAPS_HOME/.env`）。プロジェクト `.env` を先に読むことで `CLAPS_HOME` を取得し、その後インスタンス固有の `.env` を `override: true` で上書き
- **10ファイルのハードコードパス一掃**: トップレベル定数を遅延評価関数に置換し、`.env` 読み込み後に正しいパスが返るようにした
  - `src/character.ts`, `src/messages.ts`, `src/admin/store.ts`, `src/session/store.ts`, `src/history/store.ts`, `src/reflection/store.ts`, `src/reflection/intent-store.ts`, `src/approval/server.ts`, `src/http/adapter.ts`
- **`src/index.ts`**: 起動時に `CLAPS_HOME` パスをログ出力
- **`.env.example`**: `CLAPS_HOME` の設定例を追記

## レビューポイント

- **`.env` 読み込み順序** (`src/config.ts`): プロジェクト `.env` → `CLAPS_HOME/.env` の2段階読み込み。`override: true` で後者が優先される設計が意図通りか確認をお願いします
- **遅延評価パターン**: 各ファイルのトップレベル定数を関数に置換しています。ESMモジュール評価順序の制約（`dotenv.config()` 実行前にトップレベル定数が評価される問題）を回避するための対応です
- **`GetClapsDir()` の呼び出し頻度**: ファイルI/O時に毎回 `process.env['CLAPS_HOME']` を参照しますが、環境変数の読み取りは十分高速なため性能への影響はないと判断しています

## 使い方

```bash
# .env に追記
CLAPS_HOME=~/.claps-clarisse

# または起動時に環境変数で指定
CLAPS_HOME=~/.claps-clarisse npm start
```

## テスト計画

- [ ] `CLAPS_HOME` 未指定で起動 → 既存動作と同一であること
- [ ] `CLAPS_HOME=/tmp/claps-test` で起動 → そのパスにデータが保存されること
- [ ] `npm run build` が通ること ✅